### PR TITLE
fix: add florin.v1.MsgMint

### DIFF
--- a/api/v1/tx.pulsar.go
+++ b/api/v1/tx.pulsar.go
@@ -17,6 +17,974 @@ import (
 )
 
 var (
+	md_MsgMint        protoreflect.MessageDescriptor
+	fd_MsgMint_denom  protoreflect.FieldDescriptor
+	fd_MsgMint_signer protoreflect.FieldDescriptor
+	fd_MsgMint_to     protoreflect.FieldDescriptor
+	fd_MsgMint_amount protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_florin_v1_tx_proto_init()
+	md_MsgMint = File_florin_v1_tx_proto.Messages().ByName("MsgMint")
+	fd_MsgMint_denom = md_MsgMint.Fields().ByName("denom")
+	fd_MsgMint_signer = md_MsgMint.Fields().ByName("signer")
+	fd_MsgMint_to = md_MsgMint.Fields().ByName("to")
+	fd_MsgMint_amount = md_MsgMint.Fields().ByName("amount")
+}
+
+var _ protoreflect.Message = (*fastReflection_MsgMint)(nil)
+
+type fastReflection_MsgMint MsgMint
+
+func (x *MsgMint) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_MsgMint)(x)
+}
+
+func (x *MsgMint) slowProtoReflect() protoreflect.Message {
+	mi := &file_florin_v1_tx_proto_msgTypes[0]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_MsgMint_messageType fastReflection_MsgMint_messageType
+var _ protoreflect.MessageType = fastReflection_MsgMint_messageType{}
+
+type fastReflection_MsgMint_messageType struct{}
+
+func (x fastReflection_MsgMint_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_MsgMint)(nil)
+}
+func (x fastReflection_MsgMint_messageType) New() protoreflect.Message {
+	return new(fastReflection_MsgMint)
+}
+func (x fastReflection_MsgMint_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_MsgMint
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_MsgMint) Descriptor() protoreflect.MessageDescriptor {
+	return md_MsgMint
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_MsgMint) Type() protoreflect.MessageType {
+	return _fastReflection_MsgMint_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_MsgMint) New() protoreflect.Message {
+	return new(fastReflection_MsgMint)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_MsgMint) Interface() protoreflect.ProtoMessage {
+	return (*MsgMint)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_MsgMint) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.Denom != "" {
+		value := protoreflect.ValueOfString(x.Denom)
+		if !f(fd_MsgMint_denom, value) {
+			return
+		}
+	}
+	if x.Signer != "" {
+		value := protoreflect.ValueOfString(x.Signer)
+		if !f(fd_MsgMint_signer, value) {
+			return
+		}
+	}
+	if x.To != "" {
+		value := protoreflect.ValueOfString(x.To)
+		if !f(fd_MsgMint_to, value) {
+			return
+		}
+	}
+	if x.Amount != "" {
+		value := protoreflect.ValueOfString(x.Amount)
+		if !f(fd_MsgMint_amount, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_MsgMint) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "florin.v1.MsgMint.denom":
+		return x.Denom != ""
+	case "florin.v1.MsgMint.signer":
+		return x.Signer != ""
+	case "florin.v1.MsgMint.to":
+		return x.To != ""
+	case "florin.v1.MsgMint.amount":
+		return x.Amount != ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMint"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMint does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgMint) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "florin.v1.MsgMint.denom":
+		x.Denom = ""
+	case "florin.v1.MsgMint.signer":
+		x.Signer = ""
+	case "florin.v1.MsgMint.to":
+		x.To = ""
+	case "florin.v1.MsgMint.amount":
+		x.Amount = ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMint"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMint does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_MsgMint) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "florin.v1.MsgMint.denom":
+		value := x.Denom
+		return protoreflect.ValueOfString(value)
+	case "florin.v1.MsgMint.signer":
+		value := x.Signer
+		return protoreflect.ValueOfString(value)
+	case "florin.v1.MsgMint.to":
+		value := x.To
+		return protoreflect.ValueOfString(value)
+	case "florin.v1.MsgMint.amount":
+		value := x.Amount
+		return protoreflect.ValueOfString(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMint"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMint does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgMint) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "florin.v1.MsgMint.denom":
+		x.Denom = value.Interface().(string)
+	case "florin.v1.MsgMint.signer":
+		x.Signer = value.Interface().(string)
+	case "florin.v1.MsgMint.to":
+		x.To = value.Interface().(string)
+	case "florin.v1.MsgMint.amount":
+		x.Amount = value.Interface().(string)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMint"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMint does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgMint) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "florin.v1.MsgMint.denom":
+		panic(fmt.Errorf("field denom of message florin.v1.MsgMint is not mutable"))
+	case "florin.v1.MsgMint.signer":
+		panic(fmt.Errorf("field signer of message florin.v1.MsgMint is not mutable"))
+	case "florin.v1.MsgMint.to":
+		panic(fmt.Errorf("field to of message florin.v1.MsgMint is not mutable"))
+	case "florin.v1.MsgMint.amount":
+		panic(fmt.Errorf("field amount of message florin.v1.MsgMint is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMint"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMint does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_MsgMint) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "florin.v1.MsgMint.denom":
+		return protoreflect.ValueOfString("")
+	case "florin.v1.MsgMint.signer":
+		return protoreflect.ValueOfString("")
+	case "florin.v1.MsgMint.to":
+		return protoreflect.ValueOfString("")
+	case "florin.v1.MsgMint.amount":
+		return protoreflect.ValueOfString("")
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMint"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMint does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_MsgMint) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in florin.v1.MsgMint", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_MsgMint) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgMint) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_MsgMint) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_MsgMint) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*MsgMint)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		l = len(x.Denom)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.Signer)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.To)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.Amount)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*MsgMint)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if len(x.Amount) > 0 {
+			i -= len(x.Amount)
+			copy(dAtA[i:], x.Amount)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Amount)))
+			i--
+			dAtA[i] = 0x22
+		}
+		if len(x.To) > 0 {
+			i -= len(x.To)
+			copy(dAtA[i:], x.To)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.To)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if len(x.Signer) > 0 {
+			i -= len(x.Signer)
+			copy(dAtA[i:], x.Signer)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Signer)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if len(x.Denom) > 0 {
+			i -= len(x.Denom)
+			copy(dAtA[i:], x.Denom)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Denom)))
+			i--
+			dAtA[i] = 0xa
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*MsgMint)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: MsgMint: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: MsgMint: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Denom", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Denom = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Signer", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Signer = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field To", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.To = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 4:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Amount = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_MsgMintResponse protoreflect.MessageDescriptor
+)
+
+func init() {
+	file_florin_v1_tx_proto_init()
+	md_MsgMintResponse = File_florin_v1_tx_proto.Messages().ByName("MsgMintResponse")
+}
+
+var _ protoreflect.Message = (*fastReflection_MsgMintResponse)(nil)
+
+type fastReflection_MsgMintResponse MsgMintResponse
+
+func (x *MsgMintResponse) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_MsgMintResponse)(x)
+}
+
+func (x *MsgMintResponse) slowProtoReflect() protoreflect.Message {
+	mi := &file_florin_v1_tx_proto_msgTypes[1]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_MsgMintResponse_messageType fastReflection_MsgMintResponse_messageType
+var _ protoreflect.MessageType = fastReflection_MsgMintResponse_messageType{}
+
+type fastReflection_MsgMintResponse_messageType struct{}
+
+func (x fastReflection_MsgMintResponse_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_MsgMintResponse)(nil)
+}
+func (x fastReflection_MsgMintResponse_messageType) New() protoreflect.Message {
+	return new(fastReflection_MsgMintResponse)
+}
+func (x fastReflection_MsgMintResponse_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_MsgMintResponse
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_MsgMintResponse) Descriptor() protoreflect.MessageDescriptor {
+	return md_MsgMintResponse
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_MsgMintResponse) Type() protoreflect.MessageType {
+	return _fastReflection_MsgMintResponse_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_MsgMintResponse) New() protoreflect.Message {
+	return new(fastReflection_MsgMintResponse)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_MsgMintResponse) Interface() protoreflect.ProtoMessage {
+	return (*MsgMintResponse)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_MsgMintResponse) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_MsgMintResponse) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMintResponse"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMintResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgMintResponse) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMintResponse"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMintResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_MsgMintResponse) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMintResponse"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMintResponse does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgMintResponse) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMintResponse"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMintResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgMintResponse) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMintResponse"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMintResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_MsgMintResponse) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: florin.v1.MsgMintResponse"))
+		}
+		panic(fmt.Errorf("message florin.v1.MsgMintResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_MsgMintResponse) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in florin.v1.MsgMintResponse", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_MsgMintResponse) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgMintResponse) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_MsgMintResponse) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_MsgMintResponse) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*MsgMintResponse)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*MsgMintResponse)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*MsgMintResponse)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: MsgMintResponse: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: MsgMintResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
 	md_MsgBurn           protoreflect.MessageDescriptor
 	fd_MsgBurn_denom     protoreflect.FieldDescriptor
 	fd_MsgBurn_signer    protoreflect.FieldDescriptor
@@ -44,7 +1012,7 @@ func (x *MsgBurn) ProtoReflect() protoreflect.Message {
 }
 
 func (x *MsgBurn) slowProtoReflect() protoreflect.Message {
-	mi := &file_florin_v1_tx_proto_msgTypes[0]
+	mi := &file_florin_v1_tx_proto_msgTypes[2]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -712,7 +1680,7 @@ func (x *MsgBurnResponse) ProtoReflect() protoreflect.Message {
 }
 
 func (x *MsgBurnResponse) slowProtoReflect() protoreflect.Message {
-	mi := &file_florin_v1_tx_proto_msgTypes[1]
+	mi := &file_florin_v1_tx_proto_msgTypes[3]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1078,7 +2046,7 @@ func (x *MsgRecover) ProtoReflect() protoreflect.Message {
 }
 
 func (x *MsgRecover) slowProtoReflect() protoreflect.Message {
-	mi := &file_florin_v1_tx_proto_msgTypes[2]
+	mi := &file_florin_v1_tx_proto_msgTypes[4]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1746,7 +2714,7 @@ func (x *MsgRecoverResponse) ProtoReflect() protoreflect.Message {
 }
 
 func (x *MsgRecoverResponse) slowProtoReflect() protoreflect.Message {
-	mi := &file_florin_v1_tx_proto_msgTypes[3]
+	mi := &file_florin_v1_tx_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2097,6 +3065,93 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// MsgMint implements the mint (0x40c10f19) method.
+type MsgMint struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Denom  string `protobuf:"bytes,1,opt,name=denom,proto3" json:"denom,omitempty"`
+	Signer string `protobuf:"bytes,2,opt,name=signer,proto3" json:"signer,omitempty"`
+	To     string `protobuf:"bytes,3,opt,name=to,proto3" json:"to,omitempty"`
+	Amount string `protobuf:"bytes,4,opt,name=amount,proto3" json:"amount,omitempty"`
+}
+
+func (x *MsgMint) Reset() {
+	*x = MsgMint{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_florin_v1_tx_proto_msgTypes[0]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *MsgMint) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MsgMint) ProtoMessage() {}
+
+// Deprecated: Use MsgMint.ProtoReflect.Descriptor instead.
+func (*MsgMint) Descriptor() ([]byte, []int) {
+	return file_florin_v1_tx_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *MsgMint) GetDenom() string {
+	if x != nil {
+		return x.Denom
+	}
+	return ""
+}
+
+func (x *MsgMint) GetSigner() string {
+	if x != nil {
+		return x.Signer
+	}
+	return ""
+}
+
+func (x *MsgMint) GetTo() string {
+	if x != nil {
+		return x.To
+	}
+	return ""
+}
+
+func (x *MsgMint) GetAmount() string {
+	if x != nil {
+		return x.Amount
+	}
+	return ""
+}
+
+// MsgMintResponse is the response of the Mint action.
+type MsgMintResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *MsgMintResponse) Reset() {
+	*x = MsgMintResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_florin_v1_tx_proto_msgTypes[1]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *MsgMintResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MsgMintResponse) ProtoMessage() {}
+
+// Deprecated: Use MsgMintResponse.ProtoReflect.Descriptor instead.
+func (*MsgMintResponse) Descriptor() ([]byte, []int) {
+	return file_florin_v1_tx_proto_rawDescGZIP(), []int{1}
+}
+
 // MsgBurn implements the burn (0x8d1247ba) method.
 type MsgBurn struct {
 	state         protoimpl.MessageState
@@ -2113,7 +3168,7 @@ type MsgBurn struct {
 func (x *MsgBurn) Reset() {
 	*x = MsgBurn{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_florin_v1_tx_proto_msgTypes[0]
+		mi := &file_florin_v1_tx_proto_msgTypes[2]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2127,7 +3182,7 @@ func (*MsgBurn) ProtoMessage() {}
 
 // Deprecated: Use MsgBurn.ProtoReflect.Descriptor instead.
 func (*MsgBurn) Descriptor() ([]byte, []int) {
-	return file_florin_v1_tx_proto_rawDescGZIP(), []int{0}
+	return file_florin_v1_tx_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *MsgBurn) GetDenom() string {
@@ -2175,7 +3230,7 @@ type MsgBurnResponse struct {
 func (x *MsgBurnResponse) Reset() {
 	*x = MsgBurnResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_florin_v1_tx_proto_msgTypes[1]
+		mi := &file_florin_v1_tx_proto_msgTypes[3]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2189,7 +3244,7 @@ func (*MsgBurnResponse) ProtoMessage() {}
 
 // Deprecated: Use MsgBurnResponse.ProtoReflect.Descriptor instead.
 func (*MsgBurnResponse) Descriptor() ([]byte, []int) {
-	return file_florin_v1_tx_proto_rawDescGZIP(), []int{1}
+	return file_florin_v1_tx_proto_rawDescGZIP(), []int{3}
 }
 
 // MsgRecover implements the recover (0x6eb4c609) method.
@@ -2208,7 +3263,7 @@ type MsgRecover struct {
 func (x *MsgRecover) Reset() {
 	*x = MsgRecover{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_florin_v1_tx_proto_msgTypes[2]
+		mi := &file_florin_v1_tx_proto_msgTypes[4]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2222,7 +3277,7 @@ func (*MsgRecover) ProtoMessage() {}
 
 // Deprecated: Use MsgRecover.ProtoReflect.Descriptor instead.
 func (*MsgRecover) Descriptor() ([]byte, []int) {
-	return file_florin_v1_tx_proto_rawDescGZIP(), []int{2}
+	return file_florin_v1_tx_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *MsgRecover) GetDenom() string {
@@ -2270,7 +3325,7 @@ type MsgRecoverResponse struct {
 func (x *MsgRecoverResponse) Reset() {
 	*x = MsgRecoverResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_florin_v1_tx_proto_msgTypes[3]
+		mi := &file_florin_v1_tx_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2284,7 +3339,7 @@ func (*MsgRecoverResponse) ProtoMessage() {}
 
 // Deprecated: Use MsgRecoverResponse.ProtoReflect.Descriptor instead.
 func (*MsgRecoverResponse) Descriptor() ([]byte, []int) {
-	return file_florin_v1_tx_proto_rawDescGZIP(), []int{3}
+	return file_florin_v1_tx_proto_rawDescGZIP(), []int{5}
 }
 
 var File_florin_v1_tx_proto protoreflect.FileDescriptor
@@ -2297,7 +3352,23 @@ var file_florin_v1_tx_proto_rawDesc = []byte{
 	0x31, 0x2f, 0x6d, 0x73, 0x67, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x19, 0x63, 0x6f, 0x73,
 	0x6d, 0x6f, 0x73, 0x5f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73,
 	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x14, 0x67, 0x6f, 0x67, 0x6f, 0x70, 0x72, 0x6f, 0x74,
-	0x6f, 0x2f, 0x67, 0x6f, 0x67, 0x6f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x8c, 0x02, 0x0a,
+	0x6f, 0x2f, 0x67, 0x6f, 0x67, 0x6f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0xea, 0x01, 0x0a,
+	0x07, 0x4d, 0x73, 0x67, 0x4d, 0x69, 0x6e, 0x74, 0x12, 0x14, 0x0a, 0x05, 0x64, 0x65, 0x6e, 0x6f,
+	0x6d, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x64, 0x65, 0x6e, 0x6f, 0x6d, 0x12, 0x30,
+	0x0a, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x42, 0x18,
+	0xd2, 0xb4, 0x2d, 0x14, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x41, 0x64, 0x64, 0x72, 0x65,
+	0x73, 0x73, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x52, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72,
+	0x12, 0x28, 0x0a, 0x02, 0x74, 0x6f, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x42, 0x18, 0xd2, 0xb4,
+	0x2d, 0x14, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x41, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73,
+	0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x52, 0x02, 0x74, 0x6f, 0x12, 0x48, 0x0a, 0x06, 0x61, 0x6d,
+	0x6f, 0x75, 0x6e, 0x74, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x42, 0x30, 0xc8, 0xde, 0x1f, 0x00,
+	0xda, 0xde, 0x1f, 0x15, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x73, 0x64, 0x6b, 0x2e, 0x69, 0x6f,
+	0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e, 0x49, 0x6e, 0x74, 0xd2, 0xb4, 0x2d, 0x0a, 0x63, 0x6f, 0x73,
+	0x6d, 0x6f, 0x73, 0x2e, 0x49, 0x6e, 0x74, 0xa8, 0xe7, 0xb0, 0x2a, 0x01, 0x52, 0x06, 0x61, 0x6d,
+	0x6f, 0x75, 0x6e, 0x74, 0x3a, 0x23, 0x88, 0xa0, 0x1f, 0x00, 0xe8, 0xa0, 0x1f, 0x00, 0x82, 0xe7,
+	0xb0, 0x2a, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72, 0x8a, 0xe7, 0xb0, 0x2a, 0x0b, 0x66, 0x6c,
+	0x6f, 0x72, 0x69, 0x6e, 0x2f, 0x4d, 0x69, 0x6e, 0x74, 0x22, 0x11, 0x0a, 0x0f, 0x4d, 0x73, 0x67,
+	0x4d, 0x69, 0x6e, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x8c, 0x02, 0x0a,
 	0x07, 0x4d, 0x73, 0x67, 0x42, 0x75, 0x72, 0x6e, 0x12, 0x14, 0x0a, 0x05, 0x64, 0x65, 0x6e, 0x6f,
 	0x6d, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x64, 0x65, 0x6e, 0x6f, 0x6d, 0x12, 0x30,
 	0x0a, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x42, 0x18,
@@ -2332,25 +3403,29 @@ var file_florin_v1_tx_proto_rawDesc = []byte{
 	0x00, 0xe8, 0xa0, 0x1f, 0x00, 0x82, 0xe7, 0xb0, 0x2a, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72,
 	0x8a, 0xe7, 0xb0, 0x2a, 0x0e, 0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2f, 0x52, 0x65, 0x63, 0x6f,
 	0x76, 0x65, 0x72, 0x22, 0x14, 0x0a, 0x12, 0x4d, 0x73, 0x67, 0x52, 0x65, 0x63, 0x6f, 0x76, 0x65,
-	0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x32, 0x7e, 0x0a, 0x03, 0x4d, 0x73, 0x67,
-	0x12, 0x36, 0x0a, 0x04, 0x42, 0x75, 0x72, 0x6e, 0x12, 0x12, 0x2e, 0x66, 0x6c, 0x6f, 0x72, 0x69,
-	0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x4d, 0x73, 0x67, 0x42, 0x75, 0x72, 0x6e, 0x1a, 0x1a, 0x2e, 0x66,
-	0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x4d, 0x73, 0x67, 0x42, 0x75, 0x72, 0x6e,
-	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x3f, 0x0a, 0x07, 0x52, 0x65, 0x63, 0x6f,
-	0x76, 0x65, 0x72, 0x12, 0x15, 0x2e, 0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2e, 0x76, 0x31, 0x2e,
-	0x4d, 0x73, 0x67, 0x52, 0x65, 0x63, 0x6f, 0x76, 0x65, 0x72, 0x1a, 0x1d, 0x2e, 0x66, 0x6c, 0x6f,
-	0x72, 0x69, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x4d, 0x73, 0x67, 0x52, 0x65, 0x63, 0x6f, 0x76, 0x65,
-	0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x42, 0x99, 0x01, 0x0a, 0x0d, 0x63, 0x6f,
-	0x6d, 0x2e, 0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2e, 0x76, 0x31, 0x42, 0x07, 0x54, 0x78, 0x50,
-	0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x3a, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63,
-	0x6f, 0x6d, 0x2f, 0x6d, 0x6f, 0x6e, 0x65, 0x72, 0x69, 0x75, 0x6d, 0x2f, 0x6d, 0x6f, 0x64, 0x75,
-	0x6c, 0x65, 0x2d, 0x6e, 0x6f, 0x62, 0x6c, 0x65, 0x2f, 0x76, 0x32, 0x2f, 0x61, 0x70, 0x69, 0x2f,
-	0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2f, 0x76, 0x31, 0x3b, 0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e,
-	0x76, 0x31, 0xa2, 0x02, 0x03, 0x46, 0x58, 0x58, 0xaa, 0x02, 0x09, 0x46, 0x6c, 0x6f, 0x72, 0x69,
-	0x6e, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x09, 0x46, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x5c, 0x56, 0x31,
-	0xe2, 0x02, 0x15, 0x46, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x5c, 0x56, 0x31, 0x5c, 0x47, 0x50, 0x42,
-	0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02, 0x0a, 0x46, 0x6c, 0x6f, 0x72, 0x69,
-	0x6e, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x32, 0xb6, 0x01, 0x0a, 0x03, 0x4d, 0x73,
+	0x67, 0x12, 0x36, 0x0a, 0x04, 0x4d, 0x69, 0x6e, 0x74, 0x12, 0x12, 0x2e, 0x66, 0x6c, 0x6f, 0x72,
+	0x69, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x4d, 0x73, 0x67, 0x4d, 0x69, 0x6e, 0x74, 0x1a, 0x1a, 0x2e,
+	0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x4d, 0x73, 0x67, 0x4d, 0x69, 0x6e,
+	0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x36, 0x0a, 0x04, 0x42, 0x75, 0x72,
+	0x6e, 0x12, 0x12, 0x2e, 0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x4d, 0x73,
+	0x67, 0x42, 0x75, 0x72, 0x6e, 0x1a, 0x1a, 0x2e, 0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2e, 0x76,
+	0x31, 0x2e, 0x4d, 0x73, 0x67, 0x42, 0x75, 0x72, 0x6e, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x12, 0x3f, 0x0a, 0x07, 0x52, 0x65, 0x63, 0x6f, 0x76, 0x65, 0x72, 0x12, 0x15, 0x2e, 0x66,
+	0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x4d, 0x73, 0x67, 0x52, 0x65, 0x63, 0x6f,
+	0x76, 0x65, 0x72, 0x1a, 0x1d, 0x2e, 0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2e, 0x76, 0x31, 0x2e,
+	0x4d, 0x73, 0x67, 0x52, 0x65, 0x63, 0x6f, 0x76, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
+	0x73, 0x65, 0x42, 0x99, 0x01, 0x0a, 0x0d, 0x63, 0x6f, 0x6d, 0x2e, 0x66, 0x6c, 0x6f, 0x72, 0x69,
+	0x6e, 0x2e, 0x76, 0x31, 0x42, 0x07, 0x54, 0x78, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a,
+	0x3a, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6d, 0x6f, 0x6e, 0x65,
+	0x72, 0x69, 0x75, 0x6d, 0x2f, 0x6d, 0x6f, 0x64, 0x75, 0x6c, 0x65, 0x2d, 0x6e, 0x6f, 0x62, 0x6c,
+	0x65, 0x2f, 0x76, 0x32, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2f,
+	0x76, 0x31, 0x3b, 0x66, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x76, 0x31, 0xa2, 0x02, 0x03, 0x46, 0x58,
+	0x58, 0xaa, 0x02, 0x09, 0x46, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x09,
+	0x46, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x5c, 0x56, 0x31, 0xe2, 0x02, 0x15, 0x46, 0x6c, 0x6f, 0x72,
+	0x69, 0x6e, 0x5c, 0x56, 0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74,
+	0x61, 0xea, 0x02, 0x0a, 0x46, 0x6c, 0x6f, 0x72, 0x69, 0x6e, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -2365,20 +3440,24 @@ func file_florin_v1_tx_proto_rawDescGZIP() []byte {
 	return file_florin_v1_tx_proto_rawDescData
 }
 
-var file_florin_v1_tx_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_florin_v1_tx_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_florin_v1_tx_proto_goTypes = []interface{}{
-	(*MsgBurn)(nil),            // 0: florin.v1.MsgBurn
-	(*MsgBurnResponse)(nil),    // 1: florin.v1.MsgBurnResponse
-	(*MsgRecover)(nil),         // 2: florin.v1.MsgRecover
-	(*MsgRecoverResponse)(nil), // 3: florin.v1.MsgRecoverResponse
+	(*MsgMint)(nil),            // 0: florin.v1.MsgMint
+	(*MsgMintResponse)(nil),    // 1: florin.v1.MsgMintResponse
+	(*MsgBurn)(nil),            // 2: florin.v1.MsgBurn
+	(*MsgBurnResponse)(nil),    // 3: florin.v1.MsgBurnResponse
+	(*MsgRecover)(nil),         // 4: florin.v1.MsgRecover
+	(*MsgRecoverResponse)(nil), // 5: florin.v1.MsgRecoverResponse
 }
 var file_florin_v1_tx_proto_depIdxs = []int32{
-	0, // 0: florin.v1.Msg.Burn:input_type -> florin.v1.MsgBurn
-	2, // 1: florin.v1.Msg.Recover:input_type -> florin.v1.MsgRecover
-	1, // 2: florin.v1.Msg.Burn:output_type -> florin.v1.MsgBurnResponse
-	3, // 3: florin.v1.Msg.Recover:output_type -> florin.v1.MsgRecoverResponse
-	2, // [2:4] is the sub-list for method output_type
-	0, // [0:2] is the sub-list for method input_type
+	0, // 0: florin.v1.Msg.Mint:input_type -> florin.v1.MsgMint
+	2, // 1: florin.v1.Msg.Burn:input_type -> florin.v1.MsgBurn
+	4, // 2: florin.v1.Msg.Recover:input_type -> florin.v1.MsgRecover
+	1, // 3: florin.v1.Msg.Mint:output_type -> florin.v1.MsgMintResponse
+	3, // 4: florin.v1.Msg.Burn:output_type -> florin.v1.MsgBurnResponse
+	5, // 5: florin.v1.Msg.Recover:output_type -> florin.v1.MsgRecoverResponse
+	3, // [3:6] is the sub-list for method output_type
+	0, // [0:3] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -2391,7 +3470,7 @@ func file_florin_v1_tx_proto_init() {
 	}
 	if !protoimpl.UnsafeEnabled {
 		file_florin_v1_tx_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MsgBurn); i {
+			switch v := v.(*MsgMint); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2403,7 +3482,7 @@ func file_florin_v1_tx_proto_init() {
 			}
 		}
 		file_florin_v1_tx_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MsgBurnResponse); i {
+			switch v := v.(*MsgMintResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2415,7 +3494,7 @@ func file_florin_v1_tx_proto_init() {
 			}
 		}
 		file_florin_v1_tx_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MsgRecover); i {
+			switch v := v.(*MsgBurn); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2427,6 +3506,30 @@ func file_florin_v1_tx_proto_init() {
 			}
 		}
 		file_florin_v1_tx_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MsgBurnResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_florin_v1_tx_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MsgRecover); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_florin_v1_tx_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*MsgRecoverResponse); i {
 			case 0:
 				return &v.state
@@ -2445,7 +3548,7 @@ func file_florin_v1_tx_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_florin_v1_tx_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/v1/tx_grpc.pb.go
+++ b/api/v1/tx_grpc.pb.go
@@ -19,6 +19,7 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
+	Msg_Mint_FullMethodName    = "/florin.v1.Msg/Mint"
 	Msg_Burn_FullMethodName    = "/florin.v1.Msg/Burn"
 	Msg_Recover_FullMethodName = "/florin.v1.Msg/Recover"
 )
@@ -27,6 +28,7 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type MsgClient interface {
+	Mint(ctx context.Context, in *MsgMint, opts ...grpc.CallOption) (*MsgMintResponse, error)
 	Burn(ctx context.Context, in *MsgBurn, opts ...grpc.CallOption) (*MsgBurnResponse, error)
 	Recover(ctx context.Context, in *MsgRecover, opts ...grpc.CallOption) (*MsgRecoverResponse, error)
 }
@@ -37,6 +39,16 @@ type msgClient struct {
 
 func NewMsgClient(cc grpc.ClientConnInterface) MsgClient {
 	return &msgClient{cc}
+}
+
+func (c *msgClient) Mint(ctx context.Context, in *MsgMint, opts ...grpc.CallOption) (*MsgMintResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(MsgMintResponse)
+	err := c.cc.Invoke(ctx, Msg_Mint_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *msgClient) Burn(ctx context.Context, in *MsgBurn, opts ...grpc.CallOption) (*MsgBurnResponse, error) {
@@ -63,6 +75,7 @@ func (c *msgClient) Recover(ctx context.Context, in *MsgRecover, opts ...grpc.Ca
 // All implementations must embed UnimplementedMsgServer
 // for forward compatibility.
 type MsgServer interface {
+	Mint(context.Context, *MsgMint) (*MsgMintResponse, error)
 	Burn(context.Context, *MsgBurn) (*MsgBurnResponse, error)
 	Recover(context.Context, *MsgRecover) (*MsgRecoverResponse, error)
 	mustEmbedUnimplementedMsgServer()
@@ -75,6 +88,9 @@ type MsgServer interface {
 // pointer dereference when methods are called.
 type UnimplementedMsgServer struct{}
 
+func (UnimplementedMsgServer) Mint(context.Context, *MsgMint) (*MsgMintResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Mint not implemented")
+}
 func (UnimplementedMsgServer) Burn(context.Context, *MsgBurn) (*MsgBurnResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Burn not implemented")
 }
@@ -100,6 +116,24 @@ func RegisterMsgServer(s grpc.ServiceRegistrar, srv MsgServer) {
 		t.testEmbeddedByValue()
 	}
 	s.RegisterService(&Msg_ServiceDesc, srv)
+}
+
+func _Msg_Mint_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgMint)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).Mint(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Msg_Mint_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).Mint(ctx, req.(*MsgMint))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _Msg_Burn_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -145,6 +179,10 @@ var Msg_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "florin.v1.Msg",
 	HandlerType: (*MsgServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Mint",
+			Handler:    _Msg_Mint_Handler,
+		},
 		{
 			MethodName: "Burn",
 			Handler:    _Msg_Burn_Handler,

--- a/proto/florin/v1/tx.proto
+++ b/proto/florin/v1/tx.proto
@@ -10,9 +10,32 @@ import "gogoproto/gogo.proto";
 option go_package = "github.com/monerium/module-noble/v2/types/v1";
 
 service Msg {
+  rpc Mint(MsgMint) returns (MsgMintResponse);
   rpc Burn(MsgBurn) returns (MsgBurnResponse);
   rpc Recover(MsgRecover) returns (MsgRecoverResponse);
 }
+
+// MsgMint implements the mint (0x40c10f19) method.
+message MsgMint {
+  option (cosmos.msg.v1.signer) = "signer";
+  option (amino.name) = "florin/Mint";
+
+  option (gogoproto.equal) = false;
+  option (gogoproto.goproto_getters) = false;
+
+  string denom = 1;
+  string signer = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string to = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string amount = 4 [
+    (amino.dont_omitempty) = true,
+    (cosmos_proto.scalar) = "cosmos.Int",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable) = false
+  ];
+}
+
+// MsgMintResponse is the response of the Mint action.
+message MsgMintResponse {}
 
 // MsgBurn implements the burn (0x8d1247ba) method.
 message MsgBurn {

--- a/types/v1/tx.pb.go
+++ b/types/v1/tx.pb.go
@@ -32,6 +32,84 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// MsgMint implements the mint (0x40c10f19) method.
+type MsgMint struct {
+	Denom  string                `protobuf:"bytes,1,opt,name=denom,proto3" json:"denom,omitempty"`
+	Signer string                `protobuf:"bytes,2,opt,name=signer,proto3" json:"signer,omitempty"`
+	To     string                `protobuf:"bytes,3,opt,name=to,proto3" json:"to,omitempty"`
+	Amount cosmossdk_io_math.Int `protobuf:"bytes,4,opt,name=amount,proto3,customtype=cosmossdk.io/math.Int" json:"amount"`
+}
+
+func (m *MsgMint) Reset()         { *m = MsgMint{} }
+func (m *MsgMint) String() string { return proto.CompactTextString(m) }
+func (*MsgMint) ProtoMessage()    {}
+func (*MsgMint) Descriptor() ([]byte, []int) {
+	return fileDescriptor_de2a06c2ec80785c, []int{0}
+}
+func (m *MsgMint) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgMint) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgMint.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgMint) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgMint.Merge(m, src)
+}
+func (m *MsgMint) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgMint) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgMint.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgMint proto.InternalMessageInfo
+
+// MsgMintResponse is the response of the Mint action.
+type MsgMintResponse struct {
+}
+
+func (m *MsgMintResponse) Reset()         { *m = MsgMintResponse{} }
+func (m *MsgMintResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgMintResponse) ProtoMessage()    {}
+func (*MsgMintResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_de2a06c2ec80785c, []int{1}
+}
+func (m *MsgMintResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgMintResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgMintResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgMintResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgMintResponse.Merge(m, src)
+}
+func (m *MsgMintResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgMintResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgMintResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgMintResponse proto.InternalMessageInfo
+
 // MsgBurn implements the burn (0x8d1247ba) method.
 type MsgBurn struct {
 	Denom     string                `protobuf:"bytes,1,opt,name=denom,proto3" json:"denom,omitempty"`
@@ -45,7 +123,7 @@ func (m *MsgBurn) Reset()         { *m = MsgBurn{} }
 func (m *MsgBurn) String() string { return proto.CompactTextString(m) }
 func (*MsgBurn) ProtoMessage()    {}
 func (*MsgBurn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_de2a06c2ec80785c, []int{0}
+	return fileDescriptor_de2a06c2ec80785c, []int{2}
 }
 func (m *MsgBurn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -82,7 +160,7 @@ func (m *MsgBurnResponse) Reset()         { *m = MsgBurnResponse{} }
 func (m *MsgBurnResponse) String() string { return proto.CompactTextString(m) }
 func (*MsgBurnResponse) ProtoMessage()    {}
 func (*MsgBurnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_de2a06c2ec80785c, []int{1}
+	return fileDescriptor_de2a06c2ec80785c, []int{3}
 }
 func (m *MsgBurnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -124,7 +202,7 @@ func (m *MsgRecover) Reset()         { *m = MsgRecover{} }
 func (m *MsgRecover) String() string { return proto.CompactTextString(m) }
 func (*MsgRecover) ProtoMessage()    {}
 func (*MsgRecover) Descriptor() ([]byte, []int) {
-	return fileDescriptor_de2a06c2ec80785c, []int{2}
+	return fileDescriptor_de2a06c2ec80785c, []int{4}
 }
 func (m *MsgRecover) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -161,7 +239,7 @@ func (m *MsgRecoverResponse) Reset()         { *m = MsgRecoverResponse{} }
 func (m *MsgRecoverResponse) String() string { return proto.CompactTextString(m) }
 func (*MsgRecoverResponse) ProtoMessage()    {}
 func (*MsgRecoverResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_de2a06c2ec80785c, []int{3}
+	return fileDescriptor_de2a06c2ec80785c, []int{5}
 }
 func (m *MsgRecoverResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -191,6 +269,8 @@ func (m *MsgRecoverResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_MsgRecoverResponse proto.InternalMessageInfo
 
 func init() {
+	proto.RegisterType((*MsgMint)(nil), "florin.v1.MsgMint")
+	proto.RegisterType((*MsgMintResponse)(nil), "florin.v1.MsgMintResponse")
 	proto.RegisterType((*MsgBurn)(nil), "florin.v1.MsgBurn")
 	proto.RegisterType((*MsgBurnResponse)(nil), "florin.v1.MsgBurnResponse")
 	proto.RegisterType((*MsgRecover)(nil), "florin.v1.MsgRecover")
@@ -200,37 +280,40 @@ func init() {
 func init() { proto.RegisterFile("florin/v1/tx.proto", fileDescriptor_de2a06c2ec80785c) }
 
 var fileDescriptor_de2a06c2ec80785c = []byte{
-	// 469 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x92, 0x31, 0x6f, 0xd3, 0x40,
-	0x14, 0xc7, 0xed, 0x34, 0x4d, 0x95, 0x07, 0x02, 0xf5, 0x94, 0x0a, 0x63, 0x81, 0x53, 0x05, 0x09,
-	0x45, 0x51, 0xe3, 0x6b, 0x8a, 0xc4, 0xc0, 0x82, 0xc8, 0x80, 0xe8, 0x90, 0xc5, 0x6c, 0x2c, 0x28,
-	0x89, 0xaf, 0x57, 0x8b, 0xdc, 0xbd, 0xe8, 0xee, 0x6c, 0xc1, 0xc2, 0xc0, 0x84, 0x10, 0x03, 0x1f,
-	0xa1, 0x23, 0x63, 0x86, 0x7e, 0x88, 0x8e, 0x55, 0x27, 0xc4, 0x50, 0xa1, 0x64, 0x08, 0x33, 0x9f,
-	0x00, 0xd9, 0xbe, 0x50, 0x21, 0xa8, 0x3a, 0x76, 0x39, 0xdd, 0xfb, 0xbf, 0xff, 0xff, 0xe9, 0xee,
-	0xa7, 0x07, 0xe4, 0x60, 0x82, 0x2a, 0x91, 0x34, 0xeb, 0x51, 0xf3, 0x36, 0x9c, 0x2a, 0x34, 0x48,
-	0xea, 0xa5, 0x16, 0x66, 0x3d, 0x7f, 0x73, 0x28, 0x12, 0x89, 0xb4, 0x38, 0xcb, 0xae, 0x7f, 0x67,
-	0x8c, 0x5a, 0xa0, 0xa6, 0x42, 0xf3, 0x3c, 0x25, 0x34, 0xb7, 0x8d, 0xbb, 0x65, 0xe3, 0x75, 0x51,
-	0xd1, 0xb2, 0xb0, 0xad, 0x06, 0x47, 0x8e, 0xa5, 0x9e, 0xdf, 0x4a, 0xb5, 0xf5, 0xb9, 0x02, 0x1b,
-	0x03, 0xcd, 0xfb, 0xa9, 0x92, 0xa4, 0x01, 0xeb, 0x31, 0x93, 0x28, 0x3c, 0x77, 0xdb, 0x6d, 0xd7,
-	0xa3, 0xb2, 0x20, 0xbb, 0x50, 0xd3, 0x09, 0x97, 0x4c, 0x79, 0x95, 0x5c, 0xee, 0x7b, 0x67, 0xc7,
-	0xdd, 0x86, 0x9d, 0xfc, 0x2c, 0x8e, 0x15, 0xd3, 0xfa, 0xa5, 0x51, 0x89, 0xe4, 0x91, 0xf5, 0x91,
-	0x1d, 0xa8, 0x1e, 0x28, 0x14, 0xde, 0xda, 0x15, 0xfe, 0xc2, 0x45, 0x5e, 0x40, 0x6d, 0x28, 0x30,
-	0x95, 0xc6, 0xab, 0x16, 0xfe, 0xdd, 0x93, 0xf3, 0xa6, 0xf3, 0xfd, 0xbc, 0xb9, 0x55, 0x66, 0x74,
-	0xfc, 0x26, 0x4c, 0x90, 0x8a, 0xa1, 0x39, 0x0c, 0xf7, 0xa5, 0x39, 0x3b, 0xee, 0x82, 0x1d, 0xb6,
-	0x2f, 0xcd, 0xd7, 0xe5, 0xac, 0xe3, 0x46, 0x36, 0x4f, 0xee, 0x41, 0x3d, 0x7f, 0xc1, 0xd0, 0xa4,
-	0x8a, 0x79, 0xeb, 0xdb, 0x6e, 0xfb, 0x66, 0x74, 0x21, 0x3c, 0x79, 0xf0, 0xf1, 0xa8, 0xe9, 0xfc,
-	0x3c, 0x6a, 0x3a, 0x1f, 0x96, 0xb3, 0x8e, 0x7d, 0xea, 0xa7, 0xe5, 0xac, 0x73, 0xc3, 0xd2, 0xcf,
-	0x11, 0xb4, 0x36, 0xe1, 0xb6, 0xa5, 0x11, 0x31, 0x3d, 0x45, 0xa9, 0x59, 0xeb, 0x97, 0x0b, 0x30,
-	0xd0, 0x3c, 0x62, 0x63, 0xcc, 0x98, 0xba, 0x26, 0x48, 0x6d, 0xa8, 0x18, 0xb4, 0x80, 0x2e, 0xf7,
-	0x56, 0x0c, 0x5e, 0x01, 0xe1, 0xe1, 0x25, 0x10, 0x6e, 0x59, 0x08, 0xf6, 0x97, 0xad, 0x06, 0x90,
-	0x8b, 0x3f, 0xaf, 0x50, 0xec, 0xbd, 0x87, 0xb5, 0x81, 0xe6, 0xe4, 0x31, 0x54, 0x8b, 0x7d, 0x21,
-	0xe1, 0x9f, 0x25, 0x0d, 0x2d, 0x35, 0xdf, 0xff, 0x57, 0x5b, 0xc5, 0xc9, 0x53, 0xd8, 0x58, 0x51,
-	0xdc, 0xfa, 0xdb, 0x66, 0x65, 0xff, 0xfe, 0x7f, 0xe5, 0xd5, 0x80, 0xfe, 0xf3, 0x93, 0x79, 0xe0,
-	0x9e, 0xce, 0x03, 0xf7, 0xc7, 0x3c, 0x70, 0xbf, 0x2c, 0x02, 0xe7, 0x74, 0x11, 0x38, 0xdf, 0x16,
-	0x81, 0xf3, 0x6a, 0x87, 0x27, 0xe6, 0x30, 0x1d, 0x85, 0x63, 0x14, 0x54, 0xa0, 0x64, 0x2a, 0x49,
-	0xf3, 0x4b, 0x9c, 0x4e, 0x58, 0x57, 0xe2, 0x68, 0xc2, 0x68, 0xb6, 0x47, 0xcd, 0xbb, 0x29, 0xd3,
-	0x34, 0xeb, 0x8d, 0x6a, 0xc5, 0xee, 0x3f, 0xfa, 0x1d, 0x00, 0x00, 0xff, 0xff, 0xb3, 0xad, 0x7f,
-	0x1e, 0x79, 0x03, 0x00, 0x00,
+	// 515 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x94, 0x3f, 0x6f, 0x13, 0x3f,
+	0x18, 0xc7, 0xcf, 0x69, 0x9a, 0x2a, 0xfe, 0xfd, 0x04, 0xaa, 0x95, 0x8a, 0x23, 0x82, 0x4b, 0x15,
+	0x24, 0x14, 0x45, 0xcd, 0xb9, 0x29, 0x12, 0x03, 0x0b, 0x22, 0x03, 0xa2, 0x43, 0x96, 0x63, 0x63,
+	0x41, 0xf9, 0xe3, 0xba, 0x27, 0x62, 0x3f, 0x91, 0xed, 0x3b, 0xc1, 0xca, 0x84, 0x10, 0x03, 0x2f,
+	0xa1, 0x23, 0x63, 0x86, 0x8a, 0xd7, 0xd0, 0xb1, 0xea, 0x84, 0x18, 0x2a, 0x94, 0x0c, 0x41, 0x8c,
+	0xbc, 0x02, 0xe4, 0x3b, 0xa7, 0x85, 0xf2, 0x27, 0x0c, 0x95, 0x58, 0x22, 0xfb, 0xfb, 0x3c, 0x5f,
+	0xcb, 0xdf, 0x4f, 0x1e, 0x1f, 0x26, 0x7b, 0x23, 0x50, 0xb1, 0xa4, 0x69, 0x9b, 0x9a, 0xe7, 0xe1,
+	0x58, 0x81, 0x01, 0x52, 0xce, 0xb5, 0x30, 0x6d, 0x57, 0xd7, 0x7b, 0x22, 0x96, 0x40, 0xb3, 0xdf,
+	0xbc, 0x5a, 0xbd, 0x36, 0x00, 0x2d, 0x40, 0x53, 0xa1, 0xb9, 0x75, 0x09, 0xcd, 0x5d, 0xe1, 0x7a,
+	0x5e, 0x78, 0x9a, 0xed, 0x68, 0xbe, 0x71, 0xa5, 0x0a, 0x07, 0x0e, 0xb9, 0x6e, 0x57, 0xb9, 0x5a,
+	0xff, 0x82, 0xf0, 0x5a, 0x57, 0xf3, 0x6e, 0x2c, 0x0d, 0xa9, 0xe0, 0xd5, 0x21, 0x93, 0x20, 0x7c,
+	0xb4, 0x89, 0x1a, 0xe5, 0x28, 0xdf, 0x90, 0x6d, 0x5c, 0xd2, 0x31, 0x97, 0x4c, 0xf9, 0x05, 0x2b,
+	0x77, 0xfc, 0x93, 0xc3, 0x56, 0xc5, 0x9d, 0xfc, 0x60, 0x38, 0x54, 0x4c, 0xeb, 0xc7, 0x46, 0xc5,
+	0x92, 0x47, 0xae, 0x8f, 0x34, 0x70, 0xc1, 0x80, 0xbf, 0xb2, 0xa4, 0xbb, 0x60, 0x80, 0x3c, 0xc2,
+	0xa5, 0x9e, 0x80, 0x44, 0x1a, 0xbf, 0x98, 0x75, 0x6f, 0x1f, 0x9d, 0xd6, 0xbc, 0x8f, 0xa7, 0xb5,
+	0x8d, 0xdc, 0xa1, 0x87, 0xcf, 0xc2, 0x18, 0xa8, 0xe8, 0x99, 0xfd, 0x70, 0x57, 0x9a, 0x93, 0xc3,
+	0x16, 0x76, 0x47, 0xed, 0x4a, 0xf3, 0x6e, 0x3e, 0x69, 0xa2, 0xc8, 0xf9, 0xef, 0xdd, 0x7a, 0x75,
+	0x50, 0xf3, 0x3e, 0x1f, 0xd4, 0xbc, 0x97, 0xf3, 0x49, 0xd3, 0x5d, 0xe4, 0xf5, 0x7c, 0xd2, 0xfc,
+	0xcf, 0xb1, 0xb5, 0x01, 0xeb, 0xeb, 0xf8, 0xaa, 0xcb, 0x1a, 0x31, 0x3d, 0x06, 0xa9, 0x59, 0xfd,
+	0x4d, 0x21, 0xcb, 0xdf, 0x49, 0x94, 0xbc, 0xb4, 0xfc, 0x5b, 0xb8, 0xb8, 0xa7, 0x40, 0x2c, 0x25,
+	0x90, 0x75, 0x5d, 0x1e, 0x03, 0x72, 0x03, 0x97, 0xed, 0x0d, 0x7a, 0x26, 0x51, 0xcc, 0x5f, 0xdd,
+	0x44, 0x8d, 0xff, 0xa3, 0x73, 0x61, 0x29, 0x21, 0x8b, 0xc0, 0x11, 0xb2, 0xcb, 0x33, 0x42, 0x5f,
+	0x11, 0xc6, 0x5d, 0xcd, 0x23, 0x36, 0x80, 0x94, 0xa9, 0x7f, 0x04, 0x29, 0x1f, 0xa9, 0xe2, 0x5f,
+	0x8c, 0xd4, 0x9f, 0x21, 0xdc, 0xfe, 0x0d, 0x84, 0x2b, 0x0e, 0x82, 0x4b, 0x59, 0xaf, 0x60, 0x72,
+	0x9e, 0x79, 0x81, 0x62, 0xe7, 0x3d, 0xc2, 0x2b, 0x5d, 0xcd, 0xc9, 0x5d, 0x5c, 0xcc, 0x1e, 0x0c,
+	0x09, 0xcf, 0x5e, 0x69, 0xe8, 0x06, 0xab, 0x5a, 0xfd, 0x59, 0x5b, 0xf8, 0xad, 0x2f, 0x1b, 0xb4,
+	0x0b, 0x3e, 0xab, 0x5d, 0xf4, 0x7d, 0xff, 0x17, 0x90, 0xfb, 0x78, 0x6d, 0x81, 0x7f, 0xe3, 0xc7,
+	0x36, 0x27, 0x57, 0x6f, 0xfe, 0x52, 0x5e, 0x1c, 0xd0, 0x79, 0x78, 0x34, 0x0d, 0xd0, 0xf1, 0x34,
+	0x40, 0x9f, 0xa6, 0x01, 0x7a, 0x3b, 0x0b, 0xbc, 0xe3, 0x59, 0xe0, 0x7d, 0x98, 0x05, 0xde, 0x93,
+	0x2d, 0x1e, 0x9b, 0xfd, 0xa4, 0x1f, 0x0e, 0x40, 0x50, 0x01, 0x92, 0xa9, 0x38, 0xb1, 0x8b, 0x61,
+	0x32, 0x62, 0x2d, 0x09, 0xfd, 0x11, 0xa3, 0xe9, 0x0e, 0x35, 0x2f, 0xc6, 0x4c, 0xd3, 0xb4, 0xdd,
+	0x2f, 0x65, 0x1f, 0x8d, 0x3b, 0xdf, 0x02, 0x00, 0x00, 0xff, 0xff, 0x6a, 0x42, 0x77, 0xfc, 0xb2,
+	0x04, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -245,6 +328,7 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
+	Mint(ctx context.Context, in *MsgMint, opts ...grpc.CallOption) (*MsgMintResponse, error)
 	Burn(ctx context.Context, in *MsgBurn, opts ...grpc.CallOption) (*MsgBurnResponse, error)
 	Recover(ctx context.Context, in *MsgRecover, opts ...grpc.CallOption) (*MsgRecoverResponse, error)
 }
@@ -255,6 +339,15 @@ type msgClient struct {
 
 func NewMsgClient(cc grpc1.ClientConn) MsgClient {
 	return &msgClient{cc}
+}
+
+func (c *msgClient) Mint(ctx context.Context, in *MsgMint, opts ...grpc.CallOption) (*MsgMintResponse, error) {
+	out := new(MsgMintResponse)
+	err := c.cc.Invoke(ctx, "/florin.v1.Msg/Mint", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *msgClient) Burn(ctx context.Context, in *MsgBurn, opts ...grpc.CallOption) (*MsgBurnResponse, error) {
@@ -277,6 +370,7 @@ func (c *msgClient) Recover(ctx context.Context, in *MsgRecover, opts ...grpc.Ca
 
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
+	Mint(context.Context, *MsgMint) (*MsgMintResponse, error)
 	Burn(context.Context, *MsgBurn) (*MsgBurnResponse, error)
 	Recover(context.Context, *MsgRecover) (*MsgRecoverResponse, error)
 }
@@ -285,6 +379,9 @@ type MsgServer interface {
 type UnimplementedMsgServer struct {
 }
 
+func (*UnimplementedMsgServer) Mint(ctx context.Context, req *MsgMint) (*MsgMintResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Mint not implemented")
+}
 func (*UnimplementedMsgServer) Burn(ctx context.Context, req *MsgBurn) (*MsgBurnResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Burn not implemented")
 }
@@ -294,6 +391,24 @@ func (*UnimplementedMsgServer) Recover(ctx context.Context, req *MsgRecover) (*M
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
 	s.RegisterService(&_Msg_serviceDesc, srv)
+}
+
+func _Msg_Mint_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgMint)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).Mint(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/florin.v1.Msg/Mint",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).Mint(ctx, req.(*MsgMint))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _Msg_Burn_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -338,6 +453,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*MsgServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
+			MethodName: "Mint",
+			Handler:    _Msg_Mint_Handler,
+		},
+		{
 			MethodName: "Burn",
 			Handler:    _Msg_Burn_Handler,
 		},
@@ -348,6 +467,83 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "florin/v1/tx.proto",
+}
+
+func (m *MsgMint) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgMint) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgMint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size := m.Amount.Size()
+		i -= size
+		if _, err := m.Amount.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x22
+	if len(m.To) > 0 {
+		i -= len(m.To)
+		copy(dAtA[i:], m.To)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.To)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Signer) > 0 {
+		i -= len(m.Signer)
+		copy(dAtA[i:], m.Signer)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Signer)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Denom) > 0 {
+		i -= len(m.Denom)
+		copy(dAtA[i:], m.Denom)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Denom)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgMintResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgMintResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgMintResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
 }
 
 func (m *MsgBurn) Marshal() (dAtA []byte, err error) {
@@ -526,6 +722,38 @@ func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+func (m *MsgMint) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Denom)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.Signer)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.To)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = m.Amount.Size()
+	n += 1 + l + sovTx(uint64(l))
+	return n
+}
+
+func (m *MsgMintResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
 func (m *MsgBurn) Size() (n int) {
 	if m == nil {
 		return 0
@@ -605,6 +833,236 @@ func sovTx(x uint64) (n int) {
 }
 func sozTx(x uint64) (n int) {
 	return sovTx(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *MsgMint) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgMint: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgMint: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Denom", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Denom = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Signer", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Signer = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field To", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.To = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Amount.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgMintResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgMintResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgMintResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *MsgBurn) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)


### PR DESCRIPTION
To implement the feature flag I need v1 versions of `MsgMint` in addition to `MsgBurn`, and `MsgRecover`.

This PR provides that the missing `florin.v1.MsgMint`.